### PR TITLE
Helpscout Ticket 390

### DIFF
--- a/src/core/functions.php
+++ b/src/core/functions.php
@@ -491,6 +491,12 @@ abstract class ClientDash_Functions {
 		global $current_user;
 		$user_roles = $current_user->roles;
 		$user_role  = array_shift( $user_roles );
+		
+		if ( $user_role === null ) {
+			global $user_ID;
+			$user_data          = get_userdata( $user_ID );
+			$user_role          = array_shift( $user_data->roles );
+		}
 
 		return $user_role;
 	}

--- a/src/core/functions.php
+++ b/src/core/functions.php
@@ -488,15 +488,8 @@ abstract class ClientDash_Functions {
 	 */
 	public static function get_user_role() {
 
-		global $current_user;
-		$user_roles = $current_user->roles;
-		$user_role  = array_shift( $user_roles );
-		
-		if ( $user_role === null ) {
-			global $user_ID;
-			$user_data          = get_userdata( $user_ID );
-			$user_role          = array_shift( $user_data->roles );
-		}
+		$user_data = get_userdata( get_current_user_id() );
+		$user_role = array_shift( $user_data->roles );
 
 		return $user_role;
 	}


### PR DESCRIPTION
## Brief summary
User has [WP Live Chat Support](https://wordpress.org/plugins/wp-live-chat-support/) active which adds some Menu Items to any User Role with the `read` capability by default (So, pretty much any User Role).

They have a User Role created which pretty much only gets the `read` Capability. Without Client Dash replacing the menu, it works just fine.

However, when Client Dash is active, it doesn't read the User Role correctly and even if they navigate directly to that page via copy/paste it gives them a permissions denied error.

## What I've found
- Client Dash (At least v1.6.x) does not always grab the Current User's Role properly. 
    - This I've corrected in a Commit to this PR.
- When WP Live Chat Support runs `add_menu_page()` and `add_submenu_page()`, it doesn't create a full path. It just gives a basic string: `wplivechat-menu`. With the default WordPress Admin Menu this works fine, but with Client Dash it assumes that's the full path and instead of taking them to `/wp-admin/admin.php?page=wplivechat-menu` it takes them to `/wp-admin/wplivechat-menu`. While this may be considered a bug in WP Live Chat Support, since the default WordPress Admin Menu handles it fine then Client Dash probably should too.
- If you modify WP Live Chat Support to use the full Admin Page URL when it adds to the Menu, it still inexplibly causes permissions errors despite only requiring `read`. This only happens with a Client Dash Menu active for the Role.

## Site Details
```
Current WordPress version	
4.8.2

Current theme	
X – Child Theme	(child of x)

Active plugins	
akismet
all in one wp security and firewall
aryo activity log
client dash pro
client dash
contact form 7
cookie law info
cornerstone
duplicate post
easy twitter feed widget
role quick changer
user switching
wp live chat support pro
wp live chat support

Installed plugins	
Activity Log
Akismet Anti-Spam
All In One WP Security
Client Dash
Client Dash Pro
Contact Form 7
Cookie Law Info
Cornerstone
Duplicate Post
Easy Twitter Feed Widget
Envira Gallery
Essential Grid
Image Widget
Link Checker
Really Simple CAPTCHA
Role Quick Changer
Slider Revolution
Sola Support Tickets
Soliloquy
SVG Support
Tracking Code Manager
User Switching
WordPress Importer
WPBakery Visual Composer
WP Live Chat Support
WP Live Chat Support Pro
WP Meta SEO
X – Content Dock
X – Custom 404
X – Google Analytics
X – Smooth Scroll
X – Terms of Use
X – Under Construction
X – Video Lock
X – White Label

PHP Version
5.5.21
```